### PR TITLE
Add support for cluster health

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -34,7 +34,6 @@ health = {
     'yellow': 1,
     'red':    2,
 }
-
 UNKNOWN = 3
 
 
@@ -45,8 +44,8 @@ STATS_CUR = {}
 # DICT: ElasticSearch 1.0.0
 STATS_ES1 = {
     ## ES HEALTH
-    'health.status': Stat("gauge", "nodes.%s.health.status")
-    'health.number_of_nodes': Stat("gauge", "nodes.%s.health.number_of_nodes")
+    'health.status': Stat("gauge", "nodes.%s.health.status"),
+    'health.number_of_nodes': Stat("gauge", "nodes.%s.health.number_of_nodes"),
 
     ## STORE
     'indices.store.throttle-time': Stat("counter", "nodes.%s.indices.store.throttle_time_in_millis"),

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -32,8 +32,10 @@ VERBOSE_LOGGING = False
 health = {
     'green' : 0,
     'yellow': 1,
-    'red':    3,
+    'red':    2,
 }
+
+UNKNOWN = 3
 
 
 Stat = collections.namedtuple('Stat', ('type', 'path'))
@@ -233,7 +235,7 @@ def process_health(url):
     """Read a the health status from url, map health to an integer and return the json"""
     try:
         result = json.load(urllib2.urlopen(url, timeout=10))
-        result['status'] = health[result['status']] if result['status'] in health else '4'
+        result['status'] = health[result['status']] if result['status'] in health else UNKNOWN
     except urllib2.URLError, e:
         collectd.error('elasticsearch plugin: Error connecting to %s - %r' % (ES_URL, e))
         return None


### PR DESCRIPTION
Add a call to /_cluster/health that extracts the "health" section, maps it to a set of integers sends it to collectd.

The mappings are:
 0 - green health, 1 - yellow, 2 - red and 3 for an unknown health status
